### PR TITLE
Feature: camera movement

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -35,3 +35,29 @@ add_item={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"echo":false,"script":null)
 ]
 }
+camera_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"echo":false,"script":null)
+]
+}
+camera_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+]
+}
+camera_up={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"echo":false,"script":null)
+]
+}
+camera_down={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+]
+}
+
+[rendering]
+
+environment/defaults/default_clear_color=Color(0.215686, 0.215686, 0.215686, 1)
+2d/snap/snap_2d_transforms_to_pixel=true
+2d/snap/snap_2d_vertices_to_pixel=true

--- a/scenarios/TableScreen/Camera.gd
+++ b/scenarios/TableScreen/Camera.gd
@@ -1,0 +1,20 @@
+extends Camera2D
+
+const SPEED := 700
+
+var movement_direction := Vector2.ZERO
+
+func _physics_process(delta: float) -> void:
+    position += movement_direction * SPEED * delta
+
+func _unhandled_input(_input: InputEvent) -> void:
+    if get_tree().root.gui_get_focus_owner() != null:
+        movement_direction = Vector2.ZERO
+        return
+
+    movement_direction = Input.get_vector(
+        "camera_left",
+        "camera_right",
+        "camera_up",
+        "camera_down"
+    )

--- a/scenarios/TableScreen/ItemStage.gd
+++ b/scenarios/TableScreen/ItemStage.gd
@@ -18,7 +18,7 @@ func _input(event: InputEvent) -> void:
     if placeholder_item == null or not event is InputEventMouseButton:
         return
 
-    if event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+    if event.button_index == MOUSE_BUTTON_LEFT and not event.pressed:
         var syncinfo := placeholder_item._get_syncinfo()
 
         remove_child(placeholder_item)
@@ -34,6 +34,12 @@ func create_placeholder() -> void:
     add_child(placeholder_item)
 
     placeholder_item.modulate.a = PLACEHOLDER_OPACITY
+
+    var cover := Control.new()
+    cover.mouse_filter = Control.MOUSE_FILTER_STOP
+    cover.set_anchors_preset(PRESET_FULL_RECT)
+
+    placeholder_item.add_child(cover)
 
 func set_target(path: String) -> void:
     target_path = path

--- a/scenarios/TableScreen/TableScreen.gd
+++ b/scenarios/TableScreen/TableScreen.gd
@@ -1,9 +1,19 @@
 extends Control
 
-@onready var NewItemSelector: NewItemSelector = $NewItemSelector
+@onready var NewItemSelector: NewItemSelector = $FixedLayer/NewItemSelector
 @onready var ItemStage: ItemStage = $ItemStage
 @onready var TableItems: TableItems = $TableItems
 
 func _ready() -> void:
     NewItemSelector.item_requested.connect(ItemStage.set_target)
     ItemStage.item_confirmed.connect(TableItems.create_item)
+
+func _input(input: InputEvent) -> void:
+    if not input is InputEventKey:
+        return
+
+    if input.pressed and input.keycode == KEY_ESCAPE:
+        var focused := get_tree().root.gui_get_focus_owner()
+
+        if focused != null:
+            focused.release_focus()

--- a/scenarios/TableScreen/TableScreen.tscn
+++ b/scenarios/TableScreen/TableScreen.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=6 format=3 uid="uid://c2mtkd1wdlf0c"]
+[gd_scene load_steps=7 format=3 uid="uid://c2mtkd1wdlf0c"]
 
 [ext_resource type="Script" path="res://scenarios/TableScreen/TableScreen.gd" id="1_oohwr"]
+[ext_resource type="Script" path="res://scenarios/TableScreen/Camera.gd" id="2_i4s73"]
 [ext_resource type="Script" path="res://scenarios/TableScreen/TableItems.gd" id="2_ugci6"]
 [ext_resource type="Script" path="res://scenarios/TableScreen/MouseHub.gd" id="2_xrvjm"]
 [ext_resource type="Script" path="res://scenarios/TableScreen/NewItemSelector.gd" id="3_2p4jk"]
@@ -14,15 +15,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_oohwr")
-
-[node name="Background" type="ColorRect" parent="."]
-layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
-color = Color(0.215686, 0.215686, 0.215686, 1)
 
 [node name="TableItems" type="Control" parent="."]
 anchors_preset = 0
@@ -42,9 +34,16 @@ offset_right = 40.0
 offset_bottom = 40.0
 script = ExtResource("2_xrvjm")
 
-[node name="NewItemSelector" type="Control" parent="."]
+[node name="Camera" type="Camera2D" parent="."]
+position_smoothing_enabled = true
+position_smoothing_speed = 20.0
+script = ExtResource("2_i4s73")
+
+[node name="FixedLayer" type="CanvasLayer" parent="."]
+
+[node name="NewItemSelector" type="Control" parent="FixedLayer"]
 visible = false
-layout_mode = 1
+layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -52,7 +51,7 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("3_2p4jk")
 
-[node name="Background" type="ColorRect" parent="NewItemSelector"]
+[node name="Background" type="ColorRect" parent="FixedLayer/NewItemSelector"]
 layout_mode = 1
 anchors_preset = 15
 anchor_right = 1.0
@@ -61,7 +60,7 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0, 0, 0, 0.364706)
 
-[node name="Elements" type="VBoxContainer" parent="NewItemSelector"]
+[node name="Elements" type="VBoxContainer" parent="FixedLayer/NewItemSelector"]
 layout_mode = 1
 anchors_preset = -1
 anchor_top = 0.05
@@ -70,24 +69,24 @@ anchor_bottom = 0.95
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="Title" type="Label" parent="NewItemSelector/Elements"]
+[node name="Title" type="Label" parent="FixedLayer/NewItemSelector/Elements"]
 layout_mode = 2
 theme_override_font_sizes/font_size = 32
 text = "New Item"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="ScrollContainer" type="ScrollContainer" parent="NewItemSelector/Elements"]
+[node name="ScrollContainer" type="ScrollContainer" parent="FixedLayer/NewItemSelector/Elements"]
 layout_mode = 2
 size_flags_vertical = 3
 horizontal_scroll_mode = 0
 
-[node name="ItemButtons" type="VBoxContainer" parent="NewItemSelector/Elements/ScrollContainer"]
+[node name="ItemButtons" type="VBoxContainer" parent="FixedLayer/NewItemSelector/Elements/ScrollContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
 alignment = 1
 
-[node name="Button" type="Button" parent="NewItemSelector/Elements/ScrollContainer/ItemButtons"]
+[node name="Button" type="Button" parent="FixedLayer/NewItemSelector/Elements/ScrollContainer/ItemButtons"]
 visible = false
 layout_mode = 2
 text = "Example Item"

--- a/scenes/table_items/Counter/Counter.tscn
+++ b/scenes/table_items/Counter/Counter.tscn
@@ -34,6 +34,7 @@ alignment = 1
 
 [node name="PlusButton" type="Button" parent="CenterContainer/Elements"]
 layout_mode = 2
+focus_mode = 0
 theme_override_font_sizes/font_size = 32
 text = "+"
 
@@ -47,5 +48,6 @@ vertical_alignment = 1
 
 [node name="MinusButton" type="Button" parent="CenterContainer/Elements"]
 layout_mode = 2
+focus_mode = 0
 theme_override_font_sizes/font_size = 32
 text = "-"

--- a/scenes/table_items/SharedWriting/SharedWriting.tscn
+++ b/scenes/table_items/SharedWriting/SharedWriting.tscn
@@ -1,13 +1,16 @@
-[gd_scene load_steps=5 format=3 uid="uid://cd60fb56d8v1n"]
+[gd_scene load_steps=6 format=3 uid="uid://cd60fb56d8v1n"]
 
 [ext_resource type="Script" path="res://scenes/table_items/SharedWriting/SharedWriting.gd" id="1_xkyh0"]
 [ext_resource type="Texture2D" uid="uid://b1k3iveotes0w" path="res://assets/img/9p_paper.png" id="2_lvcv0"]
-[ext_resource type="Script" path="res://scenes/table_items/SharedWriting/Writing.gd" id="3_38yra"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_6xk3k"]
 
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_e3688"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_1e48p"]
+
 [node name="SharedWriting" type="Control"]
-custom_minimum_size = Vector2(512, 512)
+custom_minimum_size = Vector2(256, 256)
 layout_mode = 3
 anchors_preset = 0
 offset_right = 40.0
@@ -27,8 +30,8 @@ patch_margin_left = 64
 patch_margin_top = 64
 patch_margin_right = 64
 patch_margin_bottom = 64
-axis_stretch_horizontal = 1
-axis_stretch_vertical = 1
+axis_stretch_horizontal = 2
+axis_stretch_vertical = 2
 
 [node name="Writing" type="TextEdit" parent="."]
 layout_mode = 1
@@ -47,7 +50,8 @@ theme_override_colors/caret_color = Color(0.172549, 0.133333, 0.054902, 1)
 theme_override_constants/line_spacing = -4
 theme_override_constants/caret_width = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_6xk3k")
+theme_override_styles/focus = SubResource("StyleBoxEmpty_e3688")
+theme_override_styles/read_only = SubResource("StyleBoxEmpty_1e48p")
 placeholder_text = "Write your text here."
 wrap_mode = 1
 scroll_smooth = true
-script = ExtResource("3_38yra")

--- a/scenes/table_items/SharedWriting/Writing.gd
+++ b/scenes/table_items/SharedWriting/Writing.gd
@@ -1,8 +1,0 @@
-extends TextEdit
-
-func _gui_input(event: InputEvent) -> void:
-    if event is InputEventKey:
-        if not event.pressed:
-            if event.keycode == KEY_ESCAPE:
-                if has_focus():
-                    release_focus()


### PR DESCRIPTION
This update fixes a bug where the placeholder item is selectable, which was most conflicting for the SharedWriting one. A fully expanded Control with a Stop mouse filter is placed on top of all child items of the placeholder item to solve that.

There's smooth camera movement using WASD now and the entire program is pixel-snapped to keep all text and nodes perfectly rendered (this program doesn't need non-integer offsets).

Mouse panning is a planned feature.